### PR TITLE
Fixed malformed vendor element in various jnlp templates.

### DIFF
--- a/Scarcanoid/src/main/jnlp/template.vm
+++ b/Scarcanoid/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>Dunno<vendor/>
+   <vendor>Dunno</vendor>
    <description kind="one-line">$project.Description</description>
  </information>
 

--- a/archetype/compiled_archetype/classes/archetype-resources/src/main/jnlp/template.vm
+++ b/archetype/compiled_archetype/classes/archetype-resources/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/archetype/compiled_archetype/test-classes/projects/basic/project/basic/src/main/jnlp/template.vm
+++ b/archetype/compiled_archetype/test-classes/projects/basic/project/basic/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/archetype/src/main/resources/archetype-resources/src/main/jnlp/template.vm
+++ b/archetype/src/main/resources/archetype-resources/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/befunge/src/main/jnlp/template.vm
+++ b/befunge/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/blases/src/main/jnlp/template.vm
+++ b/blases/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/drivecontrol/src/main/jnlp/template.vm
+++ b/drivecontrol/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/icebreaker/src/main/jnlp/template.vm
+++ b/icebreaker/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/jetflight/src/main/jnlp/template.vm
+++ b/jetflight/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/life/src/main/jnlp/template.vm
+++ b/life/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
  </information>
 

--- a/liftme/src/main/jnlp/template.vm
+++ b/liftme/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/lightcycles/src/main/jnlp/template.vm
+++ b/lightcycles/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/orbitalkiller/src/main/jnlp/template.vm
+++ b/orbitalkiller/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/pong/src/main/jnlp/template.vm
+++ b/pong/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/runnegun/src/main/jnlp/template.vm
+++ b/runnegun/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
  </information>
 

--- a/simpleshooter/src/main/jnlp/template.vm
+++ b/simpleshooter/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/snake/src/main/jnlp/template.vm
+++ b/snake/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/spacewar/src/main/jnlp/template.vm
+++ b/spacewar/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/td/src/main/jnlp/template.vm
+++ b/td/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>

--- a/tetris/src/main/jnlp/template.vm
+++ b/tetris/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>dunno<vendor/>
+   <vendor>dunno</vendor>
    <description kind="one-line">$project.Description</description>
  </information>
 

--- a/uke/src/main/jnlp/template.vm
+++ b/uke/src/main/jnlp/template.vm
@@ -5,7 +5,7 @@
    href="$outputFile">
  <information>
    <title>$project.Name</title>
-   <vendor>$project.Name<vendor/>
+   <vendor>$project.Name</vendor>
    <description kind="one-line">$project.Description</description>
    <offline-allowed/>
  </information>


### PR DESCRIPTION
Several jnlp templates had this: `<vendor>Dunno<vendor/>`
which I changed to this: `<vendor>Dunno</vendor>`
